### PR TITLE
Fixed runtime error with gem

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@
 
 # rspec failure tracking
 .rspec_status
+*.gem

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -35,4 +35,4 @@ Metrics/PerceivedComplexity:
   Max: 7
 
 Style/ClassAndModuleChildren:
-  EnforcedStyle: compact
+  EnforcedStyle: nested

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    manga-tools (0.1.0)
+    manga-tools (0.1.1)
 
 GEM
   remote: https://rubygems.org/

--- a/lib/manga/tools.rb
+++ b/lib/manga/tools.rb
@@ -1,10 +1,12 @@
 # frozen_string_literal: true
 
-require 'manga/tools/cache'
-require 'manga/tools/cli'
-require 'manga/tools/http'
-require 'manga/tools/version'
+require_relative 'tools/cache'
+require_relative 'tools/cli'
+require_relative 'tools/http'
+require_relative 'tools/version'
 
-module Manga::Tools
-  class Error < StandardError; end
+module Manga
+  module Tools
+    class Error < StandardError; end
+  end
 end

--- a/lib/manga/tools/cache.rb
+++ b/lib/manga/tools/cache.rb
@@ -3,109 +3,111 @@
 require 'digest/md5'
 require 'fileutils'
 
-module Manga::Tools
-  # Cache class
-  class Cache
-    class << self
-      # Initialize cache
-      def init
-        FileUtils.mkdir_p(cache_current_year_dir)
+module Manga
+  module Tools
+    # Cache class
+    class Cache
+      class << self
+        # Initialize cache
+        def init
+          FileUtils.mkdir_p(cache_current_year_dir)
+        end
+
+        def root_dir
+          @root_dir ||= "#{Dir.home}/.manga-tools"
+        end
+
+        def cache_root_dir
+          @cache_root_dir ||= "#{root_dir}/cache"
+        end
+
+        def cache_current_year_dir
+          @cache_current_year_dir ||= "#{cache_root_dir}/#{Time.now.year}"
+        end
+
+        # @return [Integer] default expires in seconds (1day)
+        def default_expires_in
+          @default_expires_in ||= 1 * 24 * 60 * 60
+        end
+
+        # @param key [String] A key to generate a key for the cache
+        # @return [String] string of cached data
+        def fetch(key:)
+          raise ArgumentError, 'mast pass a block' unless block_given?
+
+          cache = new(key)
+          # cache.clear
+          return cache.load_data if cache.available?
+
+          result = yield(cache)
+          cache.save_meta_data
+          cache.save_data(result)
+          result
+        end
       end
 
-      def root_dir
-        @root_dir ||= "#{Dir.home}/.manga-tools"
+      # @return [Integer|nil] A cache deadline in seconds.
+      attr_accessor :expires_in
+      # @return [String] A key to generate a key for the cache.
+      attr_reader :key
+      # @return [String] A key for the cache.
+      attr_reader :cache_key
+      # @return [String] A path to the cache metadata file.
+      attr_reader :meta_file_path
+      # @return [String] A path to the cached data file.
+      attr_reader :data_file_path
+
+      # @param key [String] A key to generate a key for the cache.
+      def initialize(key)
+        raise ArgumentError, 'mast pass the key param' unless key
+
+        @expires_in = self.class.default_expires_in
+        @key = key
+        @cache_key = Digest::MD5.hexdigest(key)
+        @meta_file_path = "#{self.class.cache_current_year_dir}/#{@cache_key}"
+        @data_file_path = "#{@meta_file_path}.data"
       end
 
-      def cache_root_dir
-        @cache_root_dir ||= "#{root_dir}/cache"
+      # @return [Boolean] True if a cache is available, otherwise return false.
+      def available?
+        t = File.mtime(meta_file_path)
+        saved_expires_in = File.read(meta_file_path).strip.to_i
+
+        Time.now <= (t + saved_expires_in)
+      rescue StandardError
+        false
       end
 
-      def cache_current_year_dir
-        @cache_current_year_dir ||= "#{cache_root_dir}/#{Time.now.year}"
+      # @return [String] Reads and returns the cache data.
+      def load_data
+        File.read(data_file_path)
       end
 
-      # @return [Integer] default expires in seconds (1day)
-      def default_expires_in
-        @default_expires_in ||= 1 * 24 * 60 * 60
+      # Save the metadata for the cache.
+      def save_meta_data
+        @expires_in = self.class.default_expires_in unless expires_in
+
+        File.open(meta_file_path, 'w') do |f|
+          f.write(expires_in.to_s)
+        end
+
+        self
       end
 
-      # @param key [String] A key to generate a key for the cache
-      # @return [String] string of cached data
-      def fetch(key:)
-        raise ArgumentError, 'mast pass a block' unless block_given?
+      # @param str [String] Save the specified cache data
+      def save_data(str)
+        File.open(data_file_path, 'w') do |f|
+          f.write(str.force_encoding('utf-8'))
+        end
 
-        cache = new(key)
-        # cache.clear
-        return cache.load_data if cache.available?
-
-        result = yield(cache)
-        cache.save_meta_data
-        cache.save_data(result)
-        result
-      end
-    end
-
-    # @return [Integer|nil] A cache deadline in seconds.
-    attr_accessor :expires_in
-    # @return [String] A key to generate a key for the cache.
-    attr_reader :key
-    # @return [String] A key for the cache.
-    attr_reader :cache_key
-    # @return [String] A path to the cache metadata file.
-    attr_reader :meta_file_path
-    # @return [String] A path to the cached data file.
-    attr_reader :data_file_path
-
-    # @param key [String] A key to generate a key for the cache.
-    def initialize(key)
-      raise ArgumentError, 'mast pass the key param' unless key
-
-      @expires_in = self.class.default_expires_in
-      @key = key
-      @cache_key = Digest::MD5.hexdigest(key)
-      @meta_file_path = "#{self.class.cache_current_year_dir}/#{@cache_key}"
-      @data_file_path = "#{@meta_file_path}.data"
-    end
-
-    # @return [Boolean] True if a cache is available, otherwise return false.
-    def available?
-      t = File.mtime(meta_file_path)
-      saved_expires_in = File.read(meta_file_path).strip.to_i
-
-      Time.now <= (t + saved_expires_in)
-    rescue StandardError
-      false
-    end
-
-    # @return [String] Reads and returns the cache data.
-    def load_data
-      File.read(data_file_path)
-    end
-
-    # Save the metadata for the cache.
-    def save_meta_data
-      @expires_in = self.class.default_expires_in unless expires_in
-
-      File.open(meta_file_path, 'w') do |f|
-        f.write(expires_in.to_s)
+        self
       end
 
-      self
-    end
-
-    # @param str [String] Save the specified cache data
-    def save_data(str)
-      File.open(data_file_path, 'w') do |f|
-        f.write(str.force_encoding('utf-8'))
+      # for debug
+      def clear
+        File.delete(meta_file_path) if File.exist?(meta_file_path)
+        File.delete(data_file_path) if File.exist?(data_file_path)
       end
-
-      self
-    end
-
-    # for debug
-    def clear
-      File.delete(meta_file_path) if File.exist?(meta_file_path)
-      File.delete(data_file_path) if File.exist?(data_file_path)
     end
   end
 end

--- a/lib/manga/tools/cli.rb
+++ b/lib/manga/tools/cli.rb
@@ -5,156 +5,158 @@ require 'nokogiri'
 require 'stringio'
 require 'thor'
 
-module Manga::Tools
-  # CLI class
-  class CLI < Thor
-    def self.exit_on_failure?
-      true
-    end
-
-    # desc "pub {name}", "publication date of {name}"
-    # def pub(name)
-    #   doc = Nokogiri::HTML(
-    #     URI.open('https://tsutaya.tsite.jp/feature/book/release/comic/index', 'User-Agent' => UserAgent)
-    #   )
-    #
-    #   File.open('.index.txt', 'w') {|f| f.write doc }
-    #
-    #   results = {}
-    #
-    #   current_date = ''
-    #   state = :title
-    #   current_data = {}
-    #   doc.css('h3, div.comic_list div.c_cols-1of3 span').each do |element|
-    #     case element.name
-    #     when 'h3'
-    #       results[element.content] = []
-    #       current_date = element.content
-    #     when 'span'
-    #       current_data[state] = element.content
-    #       case state
-    #       when :title
-    #         state = :author
-    #       when :author
-    #         state = :label
-    #       when :label
-    #         state = :title
-    #         results[current_date] << current_data
-    #         current_data = {}
-    #       end
-    #     end
-    #   end
-    #
-    #   puts JSON.pretty_generate(results)
-    # end
-
-    desc 'search WORD', 'Search for a given WORD'
-    def search(word)
-      Manga::Tools::Cache.init
-
-      t = Time.now
-      url = "https://calendar.gameiroiro.com/manga.php?year=#{t.year}&month=#{t.month}"
-      data = Manga::Tools::Cache.fetch(key: url) do |cache|
-        res = Manga::Tools::Http.get(url)
-        cache.expires_in = Manga::Tools::Http.seconds_to_cache(res)
-        results = generate_internal_data(t, res.body)
-        results.to_json
+module Manga
+  module Tools
+    # CLI class
+    class CLI < Thor
+      def self.exit_on_failure?
+        true
       end
 
-      hash = JSON.parse(data)
+      # desc "pub {name}", "publication date of {name}"
+      # def pub(name)
+      #   doc = Nokogiri::HTML(
+      #     URI.open('https://tsutaya.tsite.jp/feature/book/release/comic/index', 'User-Agent' => UserAgent)
+      #   )
+      #
+      #   File.open('.index.txt', 'w') {|f| f.write doc }
+      #
+      #   results = {}
+      #
+      #   current_date = ''
+      #   state = :title
+      #   current_data = {}
+      #   doc.css('h3, div.comic_list div.c_cols-1of3 span').each do |element|
+      #     case element.name
+      #     when 'h3'
+      #       results[element.content] = []
+      #       current_date = element.content
+      #     when 'span'
+      #       current_data[state] = element.content
+      #       case state
+      #       when :title
+      #         state = :author
+      #       when :author
+      #         state = :label
+      #       when :label
+      #         state = :title
+      #         results[current_date] << current_data
+      #         current_data = {}
+      #       end
+      #     end
+      #   end
+      #
+      #   puts JSON.pretty_generate(results)
+      # end
 
-      puts "Searching '#{word}' ..."
-      hash.each do |date, items|
-        next if items.empty?
+      desc 'search WORD', 'Search for a given WORD'
+      def search(word)
+        Manga::Tools::Cache.init
 
-        items.each do |item|
-          puts "Found: #{date}, #{item['title']}" if item['title'].index(word)
+        t = Time.now
+        url = "https://calendar.gameiroiro.com/manga.php?year=#{t.year}&month=#{t.month}"
+        data = Manga::Tools::Cache.fetch(key: url) do |cache|
+          res = Manga::Tools::Http.get(url)
+          cache.expires_in = Manga::Tools::Http.seconds_to_cache(res)
+          results = generate_internal_data(t, res.body)
+          results.to_json
         end
+
+        hash = JSON.parse(data)
+
+        puts "Searching '#{word}' ..."
+        hash.each do |date, items|
+          next if items.empty?
+
+          items.each do |item|
+            puts "Found: #{date}, #{item['title']}" if item['title'].index(word)
+          end
+        end
+        puts 'Finished.'
       end
-      puts 'Finished.'
-    end
 
-    private
+      private
 
-    # @param time [Time] a target time
-    # @param data [String] a string of HTTP response body.
-    def generate_internal_data(time, data)
-      doc = Nokogiri::HTML(StringIO.open(data))
+      # @param time [Time] a target time
+      # @param data [String] a string of HTTP response body.
+      def generate_internal_data(time, data)
+        doc = Nokogiri::HTML(StringIO.open(data))
 
-      results = {}
-      current_date = nil
-      state = :genre
-      data = {}
-      doc.css(targets.join(', ')).each do |element|
-        value = rm_spaces(element.content)
-        case element.name
-        when 'td'
-          current_date = format('%<ym>s/%<day>02d', ym: time.strftime('%Y/%m'), day: value.to_i)
-          results[current_date] = []
-        when 'p', 'a'
-          case state
-          when :genre
-            guard_genre(element)
-            data[state] = value
-            state = :title
-          when :title
-            guard_title(element)
-            data[state] = value
-            data[:link] = element['href']
-            state = :company
-          when :company
-            guard_company(element)
-            data[state] = value
-            state = :authors
-          when :authors
-            guard_authors(element)
-            data[state] = value
+        results = {}
+        current_date = nil
+        state = :genre
+        data = {}
+        doc.css(targets.join(', ')).each do |element|
+          value = rm_spaces(element.content)
+          case element.name
+          when 'td'
+            current_date = format('%<ym>s/%<day>02d', ym: time.strftime('%Y/%m'), day: value.to_i)
+            results[current_date] = []
+          when 'p', 'a'
+            case state
+            when :genre
+              guard_genre(element)
+              data[state] = value
+              state = :title
+            when :title
+              guard_title(element)
+              data[state] = value
+              data[:link] = element['href']
+              state = :company
+            when :company
+              guard_company(element)
+              data[state] = value
+              state = :authors
+            when :authors
+              guard_authors(element)
+              data[state] = value
+              state = :genre
+              results[current_date] << data
+              data = {}
+            end
+          end
+        rescue StandardError
+          # when authors, authors may not be present.
+          if state == :authors
+            data[state] = ''
             state = :genre
             results[current_date] << data
             data = {}
           end
+          retry
         end
-      rescue StandardError
-        # when authors, authors may not be present.
-        if state == :authors
-          data[state] = ''
-          state = :genre
-          results[current_date] << data
-          data = {}
-        end
-        retry
+
+        results
       end
 
-      results
-    end
+      def targets
+        @targets ||= [
+          'td.day-td',
+          'div.product-description-right p.p-genre',
+          'div.product-description-right a',
+          'div.product-description-right p.p-company'
+        ]
+      end
 
-    def targets
-      @targets ||= [
-        'td.day-td',
-        'div.product-description-right p.p-genre',
-        'div.product-description-right a',
-        'div.product-description-right p.p-company'
-      ]
-    end
+      # Remove HTML spaces (&nbsp;) and white spaces.
+      # @param str [String] a string
+      def rm_spaces(str)
+        str.gsub("\u00A0", '').strip
+      end
 
-    # Remove HTML spaces (&nbsp;) and white spaces.
-    # @param str [String] a string
-    def rm_spaces(str)
-      str.gsub("\u00A0", '').strip
-    end
+      def guard_genre(element)
+        raise 'invalid state' unless element.name == 'p' && element['class'] == 'p-genre'
+      end
 
-    def guard_genre(element)
-      raise 'invalid state' unless element.name == 'p' && element['class'] == 'p-genre'
-    end
+      def guard_title(element)
+        raise 'invalid state' unless element.name == 'a'
+      end
 
-    def guard_title(element)
-      raise 'invalid state' unless element.name == 'a'
-    end
+      def guard_company(element)
+        raise 'invalid state' unless element.name == 'p' && element['class'] == 'p-company'
+      end
 
-    def guard_company(element)
-      raise 'invalid state' unless element.name == 'p' && element['class'] == 'p-company'
+      alias guard_authors guard_company
     end
-
-    alias guard_authors guard_company
   end
 end

--- a/lib/manga/tools/http.rb
+++ b/lib/manga/tools/http.rb
@@ -3,41 +3,43 @@
 require 'faraday'
 require 'uri'
 
-module Manga::Tools
-  # HTTP client class
-  module Http
-    # rubocop:disable Layout/LineLength
-    UA = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4147.105 Safari/537.36'
-    # rubocop:enable Layout/LineLength
+module Manga
+  module Tools
+    # HTTP client class
+    module Http
+      # rubocop:disable Layout/LineLength
+      UA = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4147.105 Safari/537.36'
+      # rubocop:enable Layout/LineLength
 
-    # @param url [String] an url string, eg: `https://example.com`
-    # @return [Faraday::Connection] a connection object
-    def self.connection(url)
-      @connection ||= Faraday.new(
-        url: url,
-        headers: { 'User-Agent' => UA }
-      ) do |f|
-        f.response :logger
+      # @param url [String] an url string, eg: `https://example.com`
+      # @return [Faraday::Connection] a connection object
+      def self.connection(url)
+        @connection ||= Faraday.new(
+          url: url,
+          headers: { 'User-Agent' => UA }
+        ) do |f|
+          f.response :logger
+        end
       end
-    end
 
-    # @param url [String] an url string, eg: `https://example.com/path/to/object`
-    # @return [Faraday::Response] a response object
-    def self.get(url)
-      u = URI.parse(url)
-      connection("#{u.scheme}://#{u.host}").get(u.request_uri)
-    end
+      # @param url [String] an url string, eg: `https://example.com/path/to/object`
+      # @return [Faraday::Response] a response object
+      def self.get(url)
+        u = URI.parse(url)
+        connection("#{u.scheme}://#{u.host}").get(u.request_uri)
+      end
 
-    # @param response [Faraday::Response] a response object
-    # @return [nil|Integer] number of second to cache
-    #
-    # supported http header
-    # - cache-control: max-age=[sec]
-    def self.seconds_to_cache(response)
-      result = response['cache-control']&.split(/,/)&.map(&:strip)&.find { |item| item =~ /max-age=(.+)/ }
-      return nil unless result
+      # @param response [Faraday::Response] a response object
+      # @return [nil|Integer] number of second to cache
+      #
+      # supported http header
+      # - cache-control: max-age=[sec]
+      def self.seconds_to_cache(response)
+        result = response['cache-control']&.split(/,/)&.map(&:strip)&.find { |item| item =~ /max-age=(.+)/ }
+        return nil unless result
 
-      Regexp.last_match(1).to_i
+        Regexp.last_match(1).to_i
+      end
     end
   end
 end

--- a/lib/manga/tools/version.rb
+++ b/lib/manga/tools/version.rb
@@ -1,9 +1,7 @@
 # frozen_string_literal: true
 
-# @private
 module Manga
-end
-
-module Manga::Tools
-  VERSION = '0.1.0'
+  module Tools
+    VERSION = '0.1.1'
+  end
 end

--- a/manga-tools.gemspec
+++ b/manga-tools.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.description   = 'Tools to support the automation of daily manga-related activities.'
   spec.homepage      = 'https://github.com/yagihiro/manga-tools'
   spec.license       = 'MIT'
-  spec.required_ruby_version = Gem::Requirement.new('>= 2.3.0')
+  spec.required_ruby_version = Gem::Requirement.new('>= 2.6.0')
 
   # spec.metadata['allowed_push_host'] = 'TODO: Set to 'http://mygemserver.com''
 


### PR DESCRIPTION
Fixed `uninitialized constant Manga (NameError)`

```
$ manga-tools

Traceback (most recent call last):
	8: from /Users/yagihiro/.rbenv/versions/2.7.1/bin/manga-tools:23:in `<main>'
	7: from /Users/yagihiro/.rbenv/versions/2.7.1/bin/manga-tools:23:in `load'
	6: from /Users/yagihiro/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/manga-tools-0.1.0/exe/manga-tools:4:in `<top (required)>'
	5: from /Users/yagihiro/.rbenv/versions/2.7.1/lib/ruby/2.7.0/rubygems/core_ext/kernel_require.rb:72:in `require'
	4: from /Users/yagihiro/.rbenv/versions/2.7.1/lib/ruby/2.7.0/rubygems/core_ext/kernel_require.rb:72:in `require'
	3: from /Users/yagihiro/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/manga-tools-0.1.0/lib/manga/tools.rb:3:in `<top (required)>'
	2: from /Users/yagihiro/.rbenv/versions/2.7.1/lib/ruby/2.7.0/rubygems/core_ext/kernel_require.rb:72:in `require'
	1: from /Users/yagihiro/.rbenv/versions/2.7.1/lib/ruby/2.7.0/rubygems/core_ext/kernel_require.rb:72:in `require'
/Users/yagihiro/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/manga-tools-0.1.0/lib/manga/tools/cache.rb:6:in `<top (required)>': uninitialized constant Manga (NameError)
```